### PR TITLE
Integration setup - advice on use of an access token rather than API_SECRET

### DIFF
--- a/homeassistant/components/nightscout/strings.json
+++ b/homeassistant/components/nightscout/strings.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "Enter your Nightscout server information.",
-                "description": "- URL: the address of your nightscout instance. I.e.: https://myhomeassistant.duckdns.org:5423\n- API Key (optional): Only use if your instance is protected (auth_default_roles != readable).",
+                "description": "- URL: the address of your nightscout instance. e.g.: https://myhomeassistant.duckdns.org:5423\n- API Key/Access Token (optional): Only use if your instance is protected (auth_default_roles != readable).\nIt is recommended NOT to use your API_SECRET but instead generate an access token. See https://nightscout.github.io/nightscout/security/#create-authentication-tokens-for-users for details.\nA 'subject' (person/device) with the 'readable' permission is sufficient for this integration.",
                 "data": {
                     "url": "[%key:common::config_flow::data::url%]",
                     "api_key": "[%key:common::config_flow::data::api_key%]"

--- a/homeassistant/components/nightscout/translations/en.json
+++ b/homeassistant/components/nightscout/translations/en.json
@@ -15,7 +15,7 @@
                     "api_key": "API Key",
                     "url": "URL"
                 },
-                "description": "- URL: the address of your nightscout instance. I.e.: https://myhomeassistant.duckdns.org:5423\n- API Key (optional): Only use if your instance is protected (auth_default_roles != readable).",
+                "description": "- URL: the address of your nightscout instance. e.g.: https://myhomeassistant.duckdns.org:5423\n- API Key/Access Token (optional): Only use if your instance is protected (auth_default_roles != readable).\nIt is recommended NOT to use your API_SECRET but instead generate an access token. See https://nightscout.github.io/nightscout/security/#create-authentication-tokens-for-users for details.\nA 'subject' (person/device) with the 'readable' permission is sufficient for this integration.",
                 "title": "Enter your Nightscout server information."
             }
         }


### PR DESCRIPTION
Proposed change for integration setup to advise on use of an access token rather than API_SECRET, Provide link to nightscout guide.

p.s. Thanks @marciogranzotto for your inclusion of mmol/L, much appreciated.  Looking forward to when it gets pushed to core.  Works well on my test setup.